### PR TITLE
Update Makefile (error adding symbols: DSO missing from command line)

### DIFF
--- a/ttymidi/Makefile
+++ b/ttymidi/Makefile
@@ -1,5 +1,5 @@
 all:
-	gcc src/ttymidi.c -o ttymidi -lasound
+	gcc src/ttymidi.c -o ttymidi -lasound -lpthread
 clean:
 	rm ttymidi
 install:


### PR DESCRIPTION
Added the parameter -lpthread to solve  “error adding symbols: DSO missing from command line” while compiling on newest systems